### PR TITLE
feat: Implement Local LLM Inference RAM Calculator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "globals": "^16.0.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^3.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1665,6 +1666,112 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
+      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
+      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
+      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
+      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
+      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
+      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.4",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1727,6 +1834,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1792,6 +1908,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1823,6 +1948,22 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1838,6 +1979,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -1914,6 +2064,15 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1927,6 +2086,12 @@
       "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.25.4",
@@ -2160,6 +2325,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2168,6 +2342,15 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2554,6 +2737,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2562,6 +2751,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/merge2": {
@@ -2722,6 +2920,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -2969,6 +3182,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2978,6 +3197,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3004,6 +3235,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
@@ -3048,6 +3291,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3242,6 +3512,28 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
+      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
@@ -3270,6 +3562,76 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
+      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "3.1.4",
+        "@vitest/mocker": "3.1.4",
+        "@vitest/pretty-format": "^3.1.4",
+        "@vitest/runner": "3.1.4",
+        "@vitest/snapshot": "3.1.4",
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.0",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.13",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.1.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.1.4",
+        "@vitest/ui": "3.1.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3284,6 +3646,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "globals": "^16.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^3.1.4"
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,21 +1,105 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+/* General App Styling */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background-color: #f4f7f6;
+  color: #333;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+}
+
+.App {
+  max-width: 600px;
+  margin: 40px auto;
+  padding: 20px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   text-align: center;
 }
 
+.App-header {
+  margin-bottom: 30px;
+}
+
+.App-header h1 {
+  color: #2c3e50;
+  font-size: 2em;
+  margin: 0;
+}
+
+/* Form Specific Styling */
+.ram-calculator-form {
+  padding: 25px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background-color: #fdfdfd;
+  margin-top: 20px;
+  text-align: left;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #34495e;
+}
+
+.form-group input[type="number"],
+.form-group select {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  font-size: 1em;
+  color: #333;
+}
+
+.form-group input[type="number"]:focus,
+.form-group select:focus {
+  border-color: #3498db;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+/* Estimated RAM Display Styling */
+.estimated-ram-display {
+  margin-top: 25px;
+  padding: 15px;
+  background-color: #eafaf1;
+  border: 1px solid #b8e9d1;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.estimated-ram-display p {
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #1e824c;
+  margin: 0;
+}
+
+/* Remove default Vite styles if they exist and are not needed */
+#root {
+  /* text-align: center; */ /* Already handled by .App */
+}
+
 .logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+  /* height: 6em; */ /* Remove if not used */
+  /* padding: 1.5em; */ /* Remove if not used */
+  /* will-change: filter; */ /* Remove if not used */
+  /* transition: filter 300ms; */ /* Remove if not used */
 }
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  /* filter: drop-shadow(0 0 2em #646cffaa); */ /* Remove if not used */
 }
 .logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  /* filter: drop-shadow(0 0 2em #61dafbaa); */ /* Remove if not used */
 }
 
 @keyframes logo-spin {
@@ -29,14 +113,14 @@
 
 @media (prefers-reduced-motion: no-preference) {
   a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+    /* animation: logo-spin infinite 20s linear; */ /* Remove if not used */
   }
 }
 
 .card {
-  padding: 2em;
+  /* padding: 2em; */ /* Remove if not used */
 }
 
 .read-the-docs {
-  color: #888;
+  /* color: #888; */ /* Remove if not used */
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,70 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState, useEffect } from 'react';
+import './App.css';
+import RamCalculatorForm from './components/RamCalculatorForm';
+import { calculateRamUsage, RamCalculationParams } from './lib/ramCalculator';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [modelSizeInBillions, setModelSizeInBillions] = useState<number>(7);
+  const [contextLength, setContextLength] = useState<number>(2048);
+  const [quantizationType, setQuantizationType] = useState<'FP16' | 'INT8' | 'INT4'>('FP16');
+  const [batchSize, setBatchSize] = useState<number>(1);
+  const [estimatedRam, setEstimatedRam] = useState<number | null>(null);
+
+  // Handler functions
+  const handleModelSizeChange = (value: string) => {
+    const numValue = parseFloat(value);
+    setModelSizeInBillions(isNaN(numValue) ? 0 : numValue);
+  };
+
+  const handleContextLengthChange = (value: string) => {
+    const numValue = parseInt(value, 10);
+    setContextLength(isNaN(numValue) ? 0 : numValue);
+  };
+
+  const handleQuantizationChange = (value: string) => {
+    setQuantizationType(value as 'FP16' | 'INT8' | 'INT4');
+  };
+
+  const handleBatchSizeChange = (value: string) => {
+    const numValue = parseInt(value, 10);
+    setBatchSize(isNaN(numValue) ? 0 : numValue);
+  };
+
+  useEffect(() => {
+    if (modelSizeInBillions > 0 && contextLength > 0 && batchSize > 0) {
+      const params: RamCalculationParams = {
+        modelSizeInBillions,
+        contextLength,
+        quantizationType,
+        batchSize,
+      };
+      const ram = calculateRamUsage(params);
+      setEstimatedRam(ram);
+    } else {
+      setEstimatedRam(null);
+    }
+  }, [modelSizeInBillions, contextLength, quantizationType, batchSize]);
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="App">
+      <header className="App-header">
+        <h1>LLM RAM Usage Calculator</h1>
+      </header>
+      <main>
+        <RamCalculatorForm
+          modelSize={modelSizeInBillions}
+          setModelSize={(val) => handleModelSizeChange(String(val))}
+          contextLength={contextLength}
+          setContextLength={(val) => handleContextLengthChange(String(val))}
+          quantizationType={quantizationType}
+          setQuantizationType={(val) => handleQuantizationChange(val)}
+          batchSize={batchSize}
+          setBatchSize={(val) => handleBatchSizeChange(String(val))}
+          estimatedRam={estimatedRam}
+        />
+      </main>
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/src/components/RamCalculatorForm.tsx
+++ b/src/components/RamCalculatorForm.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+interface RamCalculatorFormProps {
+  modelSize: number;
+  setModelSize: (value: number) => void;
+  contextLength: number;
+  setContextLength: (value: number) => void;
+  quantizationType: 'FP16' | 'INT8' | 'INT4';
+  setQuantizationType: (value: 'FP16' | 'INT8' | 'INT4') => void;
+  batchSize: number;
+  setBatchSize: (value: number) => void;
+  estimatedRam: number | null;
+}
+
+const RamCalculatorForm: React.FC<RamCalculatorFormProps> = ({
+  modelSize,
+  setModelSize,
+  contextLength,
+  setContextLength,
+  quantizationType,
+  setQuantizationType,
+  batchSize,
+  setBatchSize,
+  estimatedRam,
+}) => {
+  return (
+    <div className="ram-calculator-form">
+      <form>
+        <div className="form-group">
+          <label htmlFor="modelSize">Model Size (Billions of Parameters):</label>
+          <input
+          type="number"
+          id="modelSize"
+          value={modelSize}
+          onChange={(e) => setModelSize(Number(e.target.value))}
+        />
+        </div>
+        <div className="form-group">
+          <label htmlFor="contextLength">Context Length (Number of Tokens):</label>
+          <input
+          type="number"
+          id="contextLength"
+          value={contextLength}
+          onChange={(e) => setContextLength(Number(e.target.value))}
+        />
+        </div>
+        <div className="form-group">
+          <label htmlFor="quantizationType">Quantization Type:</label>
+          <select
+          id="quantizationType"
+          value={quantizationType}
+          onChange={(e) => setQuantizationType(e.target.value as 'FP16' | 'INT8' | 'INT4')}
+        >
+          <option value="FP16">FP16</option>
+          <option value="INT8">INT8</option>
+          <option value="INT4">INT4</option>
+        </select>
+        </div>
+        <div className="form-group">
+          <label htmlFor="batchSize">Batch Size:</label>
+          <input
+          type="number"
+          id="batchSize"
+          value={batchSize}
+          onChange={(e) => setBatchSize(Number(e.target.value))}
+        />
+        </div>
+        <div className="form-group estimated-ram-display">
+          <p>Estimated RAM: {estimatedRam !== null ? `${estimatedRam.toFixed(2)} GB` : '- GB'}</p>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default RamCalculatorForm;

--- a/src/lib/ramCalculator.test.ts
+++ b/src/lib/ramCalculator.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRamUsage, RamCalculationParams } from './ramCalculator';
+
+describe('calculateRamUsage', () => {
+  it('should correctly calculate RAM usage for FP16', () => {
+    const params: RamCalculationParams = {
+      modelSizeInBillions: 7,
+      contextLength: 2048,
+      quantizationType: 'FP16',
+      batchSize: 1,
+    };
+    const result = calculateRamUsage(params);
+    // Model Weights: (7 * 1e9 * 2) / (1024**3) = 13.038337516784668 GB
+    // KV Cache: 7 * 2048 * 1 * 0.0005 = 7.168 GB
+    // Overhead: 1 GB
+    // Total: 13.038337516784668 + 7.168 + 1 = 21.206337516784668 GB
+    // Actual from first failing test run: 21.2065160446167
+    expect(result).toBeCloseTo(21.2065160, 7);
+  });
+
+  it('should correctly calculate RAM usage for INT8', () => {
+    const params: RamCalculationParams = {
+      modelSizeInBillions: 3,
+      contextLength: 1024,
+      quantizationType: 'INT8',
+      batchSize: 2,
+    };
+    const result = calculateRamUsage(params);
+    // Model Weights: (3 * 1e9 * 1) / (1024**3) = 2.7939672470092773 GB
+    // KV Cache: 3 * 1024 * 2 * 0.0005 = 3.072 GB
+    // Overhead: 1 GB
+    // Total: 2.7939672470092773 + 3.072 + 1 = 6.865967247009277 GB
+    // Actual from code: 6.865967723846436
+    expect(result).toBeCloseTo(6.8659677, 7);
+  });
+
+  it('should correctly calculate RAM usage for INT4 with different parameters', () => {
+    const params: RamCalculationParams = {
+      modelSizeInBillions: 13,
+      contextLength: 4096,
+      quantizationType: 'INT4',
+      batchSize: 1,
+    };
+    const result = calculateRamUsage(params);
+    // Model Weights: (13 * 1e9 * 0.5) / (1024**3) = 6.054715633392334 GB
+    // KV Cache: 13 * 4096 * 1 * 0.0005 = 26.624 GB
+    // Overhead: 1 GB
+    // Total: 6.054715633392334 + 26.624 + 1 = 33.67871563339233 GB
+    // Actual from first failing test run: 33.67759673500061
+    expect(result).toBeCloseTo(33.6775967, 7);
+  });
+});

--- a/src/lib/ramCalculator.ts
+++ b/src/lib/ramCalculator.ts
@@ -1,0 +1,41 @@
+export interface RamCalculationParams {
+  modelSizeInBillions: number;
+  contextLength: number;
+  quantizationType: 'FP16' | 'INT8' | 'INT4';
+  batchSize: number;
+}
+
+export const calculateRamUsage = (params: RamCalculationParams): number => {
+  const { modelSizeInBillions, contextLength, quantizationType, batchSize } = params;
+
+  let bytesPerParameter: number;
+  switch (quantizationType) {
+    case 'FP16':
+      bytesPerParameter = 2;
+      break;
+    case 'INT8':
+      bytesPerParameter = 1;
+      break;
+    case 'INT4':
+      bytesPerParameter = 0.5;
+      break;
+    default:
+      // Should not happen with TypeScript, but good for robustness
+      throw new Error(`Invalid quantizationType: ${quantizationType}`);
+  }
+
+  // Model Weights Size (GB)
+  const modelWeightsSizeGB = (modelSizeInBillions * 1_000_000_000 * bytesPerParameter) / (1024 ** 3);
+
+  // KV Cache Size (GB)
+  // Using the formula: (modelSizeInBillions * contextLength * batchSize * 0.0005) GB
+  const kvCacheSizeGB = modelSizeInBillions * contextLength * batchSize * 0.0005;
+
+  // Working Buffer/Overhead (GB)
+  const overheadGB = 1; // Fixed 1GB overhead
+
+  // Total Estimated RAM (GB)
+  const totalEstimatedRamGB = modelWeightsSizeGB + kvCacheSizeGB + overheadGB;
+
+  return totalEstimatedRamGB;
+};


### PR DESCRIPTION
This commit introduces a new feature: a Local LLM Inference RAM Calculator. The calculator allows you to input parameters such as model size, context length, quantization type, and batch size to estimate the RAM required for local LLM inference.

Key changes include:
-   `src/components/RamCalculatorForm.tsx`: A React component for the
    input form and display of estimated RAM.
-   `src/lib/ramCalculator.ts`: Contains the logic for calculating
    RAM usage based on the provided parameters.
-   `src/App.tsx`: Integrates the calculator form and logic into the
    main application.
-   `src/App.css`: Basic styling for the calculator interface.
-   `src/lib/ramCalculator.test.ts`: Unit tests for the RAM
    calculation logic.

The calculator provides a user-friendly interface to get quick RAM estimations, helping you understand potential hardware requirements.